### PR TITLE
Make Sure Existing Token Is Removed Prior to Create a New Token

### DIFF
--- a/src/CustomerData/CustomerPlugin.php
+++ b/src/CustomerData/CustomerPlugin.php
@@ -31,17 +31,17 @@ class CustomerPlugin
      * @var TokenModelFactory
      */
     private $tokenModelFactory;
-    
+
     /**
      * @var OauthHelper
      */
     private $oauthHelper;
-    
+
     /**
      * @var DateTime
      */
     private $dateTime;
-    
+
     /**
      * @var Date
      */
@@ -108,6 +108,13 @@ class CustomerPlugin
         $token = $tokenModel->loadByCustomerId($customerId);
 
         if (!$token->getId() || $token->getRevoked() || $this->isTokenExpired($token)) {
+            // if there exist an entry in oauth_token table for the customer, then
+            // remove it before attempting createCustomerToken
+            if ($token->getId()) {
+                $token->delete();
+                $tokenModel = $this->tokenModelFactory->create();
+            }
+
             $token = $tokenModel->createCustomerToken($customerId);
         }
 


### PR DESCRIPTION
Magento keeps the active token in `oauth_token` table. It uses `created_at` field to check the expiry date. 

In the case there is an entry exist for a customer in the `oauth_token` table and then we try to create a new token, it actually updates the existing entry of the customer in the table rather than removing the expired entry and create a new one.

This pull request addresses this issue and it makes sure it removes the expired token in prior to creating a new token for the customer.